### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: codon_harmony
 dependencies:
-  - biopython
+  - biopython==1.73
+  - python_codon_tables==0.1.6
   - ipykernel
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 pip==19.0.3
 bumpversion==0.5.3
 wheel==0.33.1
-watchdog==0.9.0
 tox==3.7.0
 Sphinx==1.8.4
 sphinx-argparse==0.2.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,5 +6,3 @@ Sphinx==1.8.4
 sphinx-argparse==0.2.5
 coverage==4.5.2
 codecov==2.0.15
-biopython==1.73
-python_codon_tables==0.1.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,6 @@ watchdog==0.9.0
 tox==3.7.0
 Sphinx==1.8.4
 sphinx-argparse==0.2.5
-twine==1.13.0
 coverage==4.5.2
 codecov==2.0.15
 biopython==1.73


### PR DESCRIPTION
Removing:
* `twine`
* `watchdog`

Also removing the runtime dependencies (`biopython`, `python_codon_tables`) from the dev requirements file.