### PR TITLE
Updating defaults, adding options to toggle start and splice site removal

### DIFF
--- a/codon_harmony/codon_harmony.py
+++ b/codon_harmony/codon_harmony.py
@@ -55,7 +55,7 @@ def get_parser():
     parser.add_argument(
         "--cycles",
         type=int,
-        default=100,
+        default=10,
         help="number of independent codon samples to run. 0 means 1 pass",
     )
     parser.add_argument(
@@ -79,6 +79,36 @@ def get_parser():
         help="list of restriction enzyme sites to remove "
         + "(e.g. --restriction_enzymes NdeI XhoI HpaI). ",
     )
+
+    splice_sites = parser.add_mutually_exclusive_group(required=False)
+    splice_sites.add_argument(
+        "--remove-splice-sites",
+        dest="splice_sites",
+        action="store_true",
+        help="Remove splice sites. Use for mammalian hosts.",
+    )
+    splice_sites.add_argument(
+        "--no-remove-splice-sites",
+        dest="splice_sites",
+        action="store_false",
+        help="Do not remove splice sites.",
+    )
+    parser.set_defaults(splice_sites=True)
+
+    start_sites = parser.add_mutually_exclusive_group(required=False)
+    start_sites.add_argument(
+        "--remove-start-sites",
+        dest="start_sites",
+        action="store_true",
+        help="Remove alternate start sites. Use for bacterial hosts.",
+    )
+    start_sites.add_argument(
+        "--no-remove-start-sites",
+        dest="start_sites",
+        action="store_false",
+        help="Do not remove alternate start sites.",
+    )
+    parser.set_defaults(start_sites=True)
 
     return parser
 
@@ -146,9 +176,11 @@ def main(argv=None):
                     # check various GC content requirements
                     dna = seq_opt.gc_scan(dna, codon_use_table, gc_content)
 
-                dna = seq_opt.remove_start_sites(
-                    dna, codon_use_table, RibosomeBindingSites
-                )
+                if args.start_sites:
+                    dna = seq_opt.remove_start_sites(
+                        dna, codon_use_table, RibosomeBindingSites
+                    )
+
                 dna = seq_opt.remove_repeating_sequences(dna, codon_use_table, 9)
                 dna = seq_opt.remove_local_homopolymers(
                     dna,
@@ -193,8 +225,9 @@ def main(argv=None):
             )
             continue
 
-        logger.output("Detecting and removing splice sites before outputting.")
-        best_dna.seq = seq_opt.remove_splice_sites(best_dna.seq, codon_use_table)
+        if args.splice_sites:
+            logger.output("Detecting and removing splice sites before outputting.")
+            best_dna.seq = seq_opt.remove_splice_sites(best_dna.seq, codon_use_table)
 
         logger.output("Optimized gene metrics and sequence")
         # check GC content

--- a/tests/test_codon_harmony.py
+++ b/tests/test_codon_harmony.py
@@ -30,7 +30,7 @@ class TestCodon_tools(unittest.TestCase):
         parsed_args = parser.parse_args(self.args_to_parse)
         assert parsed_args.input == "misc/INPUT_LIST.fasta"
         assert parsed_args.output == "out.fasta"
-        assert parsed_args.cycles == 100
+        assert parsed_args.cycles == 10
         assert parsed_args.host == "413997"
         assert parsed_args.host_threshold == 0.1
         assert parsed_args.inner_cycles == 10
@@ -46,6 +46,8 @@ class TestCodon_tools(unittest.TestCase):
             "BamHI",
         ]
         assert parsed_args.verbose == 0
+        assert parsed_args.splice_sites
+        assert parsed_args.start_sites
 
     def test_main(self):
         """Test `codon_harmony` main function"""


### PR DESCRIPTION
Add the ability to turn off start and splice site detection and removal. This is useful because these steps are only necessary depending on the host system being used. For now it is up to the user to know when to turn these features on and off.

Also adjusting the default number of cycles down from 100 to 10.

